### PR TITLE
Remove socat range setting

### DIFF
--- a/src/scripts/functions.sh
+++ b/src/scripts/functions.sh
@@ -216,17 +216,17 @@ function mks {
 
 function uhv {
     overlay_PRUserial485
-    socat TCP-LISTEN:5004,reuseaddr,fork,nodelay,range=${SERVER_IP_ADDR} FILE:${SOCAT_DEVICE},b${BAUDRATE}
+    socat TCP-LISTEN:5004,reuseaddr,fork,nodelay FILE:${SOCAT_DEVICE},b${BAUDRATE}
 }
 
 function mbtemp {
     overlay_PRUserial485
     echo  "Starting socat..."
-    socat TCP-LISTEN:5003,reuseaddr,fork,nodelay,range=${SERVER_IP_ADDR} FILE:${SOCAT_DEVICE},b${BAUDRATE}
+    socat TCP-LISTEN:5003,reuseaddr,fork,nodelay FILE:${SOCAT_DEVICE},b${BAUDRATE}
 }
 
 function socat_devices {
     overlay_PRUserial485
     echo  "Starting socat..."
-    socat TCP-LISTEN:${SOCAT_PORT},reuseaddr,fork,nodelay,range=${SERVER_IP_ADDR} FILE:${SOCAT_DEVICE},b${BAUDRATE},rawer
+    socat TCP-LISTEN:${SOCAT_PORT},reuseaddr,fork,nodelay FILE:${SOCAT_DEVICE},b${BAUDRATE},rawer
 }


### PR DESCRIPTION
Due to recent changes this range limitation is not required and may cause problems depending on which server the IOC is running on