### PR TITLE
Adds missing Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 ftputil==3.4
 msgpack==0.6.1
 xlrd==1.2.0
+pyserial==3.5
+redis==3.5.3


### PR DESCRIPTION
The Redis requirement is more of a redundancy. [CountingPRU](https://github.com/lnls-sirius/counting-pru) code running Python 2.7 requires it, so for future updates that move to 3.6, it'd be better to have it