### PR TITLE
Bug fix - Prevents service from restarting when incorrect IP id found.

### DIFF
--- a/src/run-functions.sh
+++ b/src/run-functions.sh
@@ -14,7 +14,7 @@ popd
 
 
 # Wait a few seconds before starting
-sleep 30
+#sleep 30
 
 
 # Updating etc folder and bbb-function if rsync server available.

--- a/src/scripts/autoConfig.py
+++ b/src/scripts/autoConfig.py
@@ -85,7 +85,7 @@ class AutoConfig:
 
         elif (currentIPvalue[:7] != '10.128.') or (currentIPvalue[:5] != '10.0.'):
             logger.error("Unknown IP {}. Wait a valid one! Restarting service...".format(
-                                mybbb.currentIP,
+                                currentIPvalue,
                             )
                 )
             system('systemctl restart bbb-function')


### PR DESCRIPTION
Just a variable renaming and removing an sleep directive.
This closes issue #51 