### PR TITLE
Organizing counting-pru folder & new PU names

### DIFF
--- a/src/scripts/AUTOCONFIG.json
+++ b/src/scripts/AUTOCONFIG.json
@@ -21,13 +21,13 @@
             {"BBB_IP_1": "10.128.101.118", "BBB_IP_2": "", "BBB_HOSTNAME": "BBB-SALA01-CON-MBTEMP-SR-AFTER-BC", "DEVICE_TYPE": "MBTemp", "DEVICE_ID": [21, 22, 23], "DEVICE_NAME": ""}
             ], 
         "SPIxCONV": [
-            {"BBB_IP_1": "10.128.101.161", "BBB_IP_2": "", "BBB_HOSTNAME": "NLK-ON-AXIS-1", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "NLK-ON-AXIS-1"}, 
-            {"BBB_IP_1": "10.128.101.162", "BBB_IP_2": "", "BBB_HOSTNAME": "BOO-INJ-SEP", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "BOO-INJ-SEP"}, 
-            {"BBB_IP_1": "10.128.101.163", "BBB_IP_2": "", "BBB_HOSTNAME": "SR-INJ-THICK-SEP-1", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "SR-INJ-THICK-SEP-1"}, 
-            {"BBB_IP_1": "10.128.101.164", "BBB_IP_2": "", "BBB_HOSTNAME": "NLK-ON-AXIS-2", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "NLK-ON-AXIS-2"}, 
-            {"BBB_IP_1": "10.128.101.165", "BBB_IP_2": "", "BBB_HOSTNAME": "S-R-INJ-THIN-SEP", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "S-R-INJ-THIN-SEP"}, 
-            {"BBB_IP_1": "10.128.101.166", "BBB_IP_2": "", "BBB_HOSTNAME": "SR-INJ-THICK-SEP-2", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "SR-INJ-THICK-SEP-2"}, 
-            {"BBB_IP_1": "10.128.101.167", "BBB_IP_2": "", "BBB_HOSTNAME": "BOO-INJ-KICKER", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "BOO-INJ-KICKER"}
+            {"BBB_IP_1": "10.128.101.161", "BBB_IP_2": "", "BBB_HOSTNAME": "SI-InjDpKckr", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "SI-InjDpKckr"}, 
+            {"BBB_IP_1": "10.128.101.162", "BBB_IP_2": "", "BBB_HOSTNAME": "TB-InjSept", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "TB-InjSept"}, 
+            {"BBB_IP_1": "10.128.101.163", "BBB_IP_2": "", "BBB_HOSTNAME": "TS-InjSeptG-1", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "TS-InjSeptG-1"}, 
+            {"BBB_IP_1": "10.128.101.164", "BBB_IP_2": "", "BBB_HOSTNAME": "SI-InjNLKckr", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "SI-InjNLKckr"}, 
+            {"BBB_IP_1": "10.128.101.165", "BBB_IP_2": "", "BBB_HOSTNAME": "TS-InjSeptF", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "TS-InjSeptF"}, 
+            {"BBB_IP_1": "10.128.101.166", "BBB_IP_2": "", "BBB_HOSTNAME": "TS-InjSeptG-2", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "TS-InjSeptG-2"}, 
+            {"BBB_IP_1": "10.128.101.167", "BBB_IP_2": "", "BBB_HOSTNAME": "BO-InjKckr", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "BO-InjKckr"}
             ], 
         "SIMAR": [
             {"BBB_IP_1": "10.128.101.141", "BBB_IP_2": "", "BBB_HOSTNAME": "BBB-SIMAR-IA01-RaCtrl1", "DEVICE_TYPE": "SIMAR", "DEVICE_ID": [1], "DEVICE_NAME": ""}
@@ -514,10 +514,10 @@
             {"BBB_IP_1": "10.128.120.118", "BBB_IP_2": "", "BBB_HOSTNAME": "BBB-SALA20-CON-MBTEMP-SR-AFTER-BC", "DEVICE_TYPE": "MBTemp", "DEVICE_ID": [21, 22, 23], "DEVICE_NAME": ""}
             ], 
         "SPIxCONV": [
-            {"BBB_IP_1": "10.128.120.161", "BBB_IP_2": "", "BBB_HOSTNAME": "SR-PING-V", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "SR-PING-V"}, 
-            {"BBB_IP_1": "10.128.120.162", "BBB_IP_2": "", "BBB_HOSTNAME": "BOO-EXT-THIN-SEP", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "BOO-EXT-THIN-SEP"}, 
-            {"BBB_IP_1": "10.128.120.163", "BBB_IP_2": "", "BBB_HOSTNAME": "BOO-EXT-THICK-SEP", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "BOO-EXT-THICK-SEP"}, 
-            {"BBB_IP_1": "10.128.120.164", "BBB_IP_2": "", "BBB_HOSTNAME": "BOO-EXT-KICKER", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "BOO-EXT-KICKER"}
+            {"BBB_IP_1": "10.128.120.161", "BBB_IP_2": "", "BBB_HOSTNAME": "SI-PingV", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "SI-PingV"}, 
+            {"BBB_IP_1": "10.128.120.162", "BBB_IP_2": "", "BBB_HOSTNAME": "TS-EjeSeptF", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "TS-EjeSeptF"}, 
+            {"BBB_IP_1": "10.128.120.163", "BBB_IP_2": "", "BBB_HOSTNAME": "TS-EjeSeptG", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "TS-EjeSeptG"}, 
+            {"BBB_IP_1": "10.128.120.164", "BBB_IP_2": "", "BBB_HOSTNAME": "BO-EjeKckr", "DEVICE_TYPE": "SPIxCONV", "DEVICE_ID": [], "DEVICE_NAME": "BO-EjeKckr"}
             ], 
         "SIMAR": [
             {"BBB_IP_1": "10.128.120.142", "BBB_IP_2": "", "BBB_HOSTNAME": "BBB-SIMAR-IA20-RaCtrl1", "DEVICE_TYPE": "SIMAR", "DEVICE_ID": [7], "DEVICE_NAME": ""}

--- a/src/scripts/autoConfig.py
+++ b/src/scripts/autoConfig.py
@@ -54,7 +54,7 @@ class AutoConfig:
                             break
                         sleep(2)
                 else:
-                    system("/root/counting-pru/src/DTO_CountingPRU.sh")
+                    system("/root/counting-pru/src/pinconfig_counting-pru.sh")
                     for i in range(5):
                         self.status = self.counter.autoConfig_Available()
                         if self.status:

--- a/src/scripts/devices.py
+++ b/src/scripts/devices.py
@@ -175,7 +175,7 @@ def counting_pru():
     logger.debug("Counting PRU")
     if PRUserial485_address() != 21 and not os.path.exists(PORT):
         counters = CountingPRU_addr()
-        os.system("/root/counting-pru/src/DTO_CountingPRU.sh")
+        os.system("/root/counting-pru/src/pinconfig_counting-pru.sh")
         name = "Counting PRU"
         persist_info(
             Type.COUNTING_PRU,

--- a/src/scripts/functions.sh
+++ b/src/scripts/functions.sh
@@ -111,13 +111,13 @@ function overlay_CountingPRU {
         exit 1
     fi
 
-    if [ ! -f /root/counting-pru/src/DTO_CountingPRU.sh ]; then
-        echo "[ERROR] counting-pru:  The file /root/counting-pru/src/DTO_CountingPRU.sh doesn\'t exist."
+    if [ ! -f /root/counting-pru/src/pinconfig_counting-pru.sh ]; then
+        echo "[ERROR] counting-pru:  The file /root/counting-pru/src/pinconfig_counting-pru.sh doesn\'t exist."
         exit 1
     fi
 
     pushd /root/counting-pru/src
-        ./DTO_CountingPRU.sh
+        ./pinconfig_counting-pru.sh
     popd
 }
 
@@ -157,12 +157,12 @@ function counting_pru {
         exit 1
     fi
 
-    if [ ! -f /root/counting-pru/IOC/SI-CountingPRU_Socket.py ]; then
+    if [ ! -f /root/counting-pru/ioc-interface/SI-CountingPRU_Socket.py ]; then
         echo "[ERROR] CountingPRU: The file /root/counting-pru/IOC/SI-CountingPRU_Socket.py doesn\'t exist."
         exit 1
     fi
 
-    pushd /root/counting-pru/IOC
+    pushd /root/counting-pru/ioc-interface
         ./SI-CountingPRU_Socket.py
     popd
 }


### PR DESCRIPTION
**counting-pru:**

- socket on `/ioc-interface` folder
- pin config renamed from `DTO_CountingPRU.sh` to `pinconfig_counting-pru.sh`


**Pulsed magnets:**

- Flipping DpKckr and NLKckr order (old _NLK-ON-AXIS-1_ & _NLK-ON-AXIS-2_)