### PR TITLE
Added systemctl dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX ?= /usr/local
 
 FUNCTION_SERVICE_NAME = bbb-function
 FUNCTION_SRC_SERVICE_FILE = ${FUNCTION_SERVICE_NAME}.service
-
+FUNCTION_DEPENDENCIES = systemd-networkd systemd-networkd-wait-online
 SERVICE_FILE_DEST = /etc/systemd/system
 
 .PHONY: all install uninstall dependencies clean
@@ -17,6 +17,10 @@ install:
 	pip3.6 install Adafruit_BBIO
 
 	systemctl daemon-reload
+	
+	# enable and start dependencies
+	systemctl enable ${FUNCTION_DEPENDENCIES}
+	systemctl start ${FUNCTION_DEPENDENCIES}
 
 	systemctl enable ${FUNCTION_SERVICE_NAME}
 	systemctl restart ${FUNCTION_SERVICE_NAME}

--- a/services/bbb-function.service
+++ b/services/bbb-function.service
@@ -8,7 +8,6 @@ Restart=always
 RestartSec=3
 Type=simple 
 WorkingDirectory=/root/bbb-function/
-ExecStartPre=/bin/sleep 5
 ExecStart=/bin/bash /root/bbb-function/src/run-functions.sh
 StandardOutput=syslog
 StandardError=syslog


### PR DESCRIPTION
This PR fixes the bug that caused the bbb-function service to start before the network is fully up. Although the bbb-function service includes the line `Wants=network-online.target`, we empirically verified that it only works if both `systemd-networkd` AND `systemd-networkd-wait-online` services are enabled, which is not the case by default in the current image.

Since other applications (like bbbread) may also need this fix, I suggest adding it at a lower level in the image.

This PR also removes a five-second sleep that had previously been added to the service startup as a workaround for the connection problem. We observed that this five-second delay was insufficient for the network to become fully operational. If an active wait is truly needed, it should be about 15 seconds to ensure the network is completely up, as verified empirically.