### PR TITLE
Improve autoconfig retrieval

### DIFF
--- a/src/scripts/autoConfig.py
+++ b/src/scripts/autoConfig.py
@@ -48,8 +48,8 @@ class AutoConfig:
         Check whether AUTOCONFIG is enabled only for some subnets
         """
         currentIPvalue = self.get_ip()
-        if((currentIPvalue.split(".")[2] in CONFIGURED_SUBNETS) and (currentIPvalue.startswith(CONTROLS_INFRA)))
-            or (currentIPvalue.startswith(ISP_INFRA))
+        if((currentIPvalue.split(".")[2] in CONFIGURED_SUBNETS) and (currentIPvalue.startswith(CONTROLS_INFRA))) \
+            or (currentIPvalue.startswith(ISP_INFRA)) \
             or (currentIPvalue.startswith(DAT_INFRA)):
                 # COUNTINGPRU
                 if self.boardID == COUNTINGPRU_SIMAR_ID:
@@ -92,8 +92,8 @@ class AutoConfig:
             read_usb = self.read_folder()
             self.status = True
 
-        elif not(currentIPvalue.startswith(CONTROLS_INFRA))
-            and not(currentIPvalue.startswith(DAT_INFRA))
+        elif not(currentIPvalue.startswith(CONTROLS_INFRA)) \
+            and not(currentIPvalue.startswith(DAT_INFRA)) \
             and not(currentIPvalue.startswith(ISP_GIE_INFRA)):
                 logger.error("Unknown IP {}. Wait a valid one! Restarting service...".format(
                                     currentIPvalue,
@@ -233,7 +233,7 @@ if __name__ == "__main__":
             subnet = mybeagle_config[BBB_IP_1_COLUMN].split(".")[2]
 
             # Update IP, if available
-            if currentIPvalue.startswith(CONTROLS_INFRA):
+            if mybbb.currentIP.startswith(CONTROLS_INFRA):
                 if (IP_AVAILABLE_1 or IP_AVAILABLE_2) and subnet == mybbb.currentSubnet:
                     if IP_AVAILABLE_1:
                         new_ip = mybeagle_config[BBB_IP_1_COLUMN]
@@ -277,7 +277,7 @@ if __name__ == "__main__":
 
 
         # IT network, ISP laboratory. Then:
-        elif(mybbb.type == "SPIxCONV" and currentIPvalue.startswith(ISP_INFRA)):
+        elif(mybbb.type == "SPIxCONV" and mybbb.currentIP.startswith(ISP_INFRA)):
             mybbb.update_ip_address(
                 "manual",
                 new_ip_address="10.20.11.190",
@@ -324,7 +324,7 @@ if __name__ == "__main__":
 
 
                 # Update IP, if available
-                if mybbb.currentIP[:7] == '10.128.':
+                if mybbb.currentIP.startswith(CONTROLS_INFRA):
                     if (IP_AVAILABLE_1 or IP_AVAILABLE_2) and subnet == mybbb.currentSubnet:
                         if IP_AVAILABLE_1:
                             new_ip = mybeagle_config[BBB_IP_1_COLUMN]

--- a/src/scripts/autoConfig.py
+++ b/src/scripts/autoConfig.py
@@ -28,8 +28,8 @@ CONFIGURED_SUBNETS = ["101", "102", "103", "104", "105", "106", \
 
 # IP Infras
 CONTROLS_INFRA = "10.128."
-ISP_INFRA = "10.20.11."
-ISP_GIE_INFRA = "10.20."
+EPP_INFRA = "10.20.11."
+EPP_GIE_INFRA = "10.20."
 DAT_INFRA = "10.0.4."
 
 
@@ -49,7 +49,7 @@ class AutoConfig:
         """
         currentIPvalue = self.get_ip()
         if((currentIPvalue.split(".")[2] in CONFIGURED_SUBNETS) and (currentIPvalue.startswith(CONTROLS_INFRA))) \
-            or (currentIPvalue.startswith(ISP_INFRA)) \
+            or (currentIPvalue.startswith(EPP_INFRA)) \
             or (currentIPvalue.startswith(DAT_INFRA)):
                 # COUNTINGPRU
                 if self.boardID == COUNTINGPRU_SIMAR_ID:
@@ -94,7 +94,7 @@ class AutoConfig:
 
         elif not(currentIPvalue.startswith(CONTROLS_INFRA)) \
             and not(currentIPvalue.startswith(DAT_INFRA)) \
-            and not(currentIPvalue.startswith(ISP_GIE_INFRA)):
+            and not(currentIPvalue.startswith(EPP_GIE_INFRA)):
                 logger.error("Unknown IP {}. Wait a valid one! Restarting service...".format(
                                     currentIPvalue,
                                 )
@@ -277,7 +277,7 @@ if __name__ == "__main__":
 
 
         # IT network, ISP laboratory. Then:
-        elif(mybbb.type == "SPIxCONV" and mybbb.currentIP.startswith(ISP_INFRA)):
+        elif(mybbb.type == "SPIxCONV" and mybbb.currentIP.startswith(EPP_INFRA)):
             mybbb.update_ip_address(
                 "manual",
                 new_ip_address="10.20.11.190",

--- a/src/scripts/autoConfig.py
+++ b/src/scripts/autoConfig.py
@@ -124,7 +124,11 @@ class GetData:
     def __init__(self, csconsts_url = CONTROL_SYSTEM_CONSTS_AUTOCONFIG_FILE, datafile=AUTOCONFIG_FILE, subnet=""):
         try:
             logger.info("Retrieving AUTOCONFIG file from control-system-constants")
-            system('wget -c --read-timeout=5 --tries=3 -O {} {}'.format(AUTOCONFIG_FILE, CONTROL_SYSTEM_CONSTS_AUTOCONFIG_FILE))
+            ret = system('wget --read-timeout=5 --tries=3 -O {} {}'.format(AUTOCONFIG_FILE_TMP, CONTROL_SYSTEM_CONSTS_AUTOCONFIG_FILE))
+            if ret == 0:
+                system("mv {} {}".format(AUTOCONFIG_FILE_TMP, AUTOCONFIG_FILE))
+            else:
+                system("rm -f {}".format(AUTOCONFIG_FILE_TMP))
 
             if ".xlsx" in AUTOCONFIG_FILE:
                 _sheet = open_workbook(datafile).sheet_by_name(subnet)

--- a/src/scripts/autoConfig.py
+++ b/src/scripts/autoConfig.py
@@ -26,6 +26,13 @@ CONFIGURED_SUBNETS = ["101", "102", "103", "104", "105", "106", \
 "131", "132", "133", "134", "135", "136", "137"]
 
 
+# IP Infras
+CONTROLS_INFRA = "10.128."
+ISP_INFRA = "10.20.11."
+ISP_GIE_INFRA = "10.20."
+DAT_INFRA = "10.0.4."
+
+
 class AutoConfig:
     def __init__(self):
         self.boardID = PRUserial485_address()
@@ -41,41 +48,43 @@ class AutoConfig:
         Check whether AUTOCONFIG is enabled only for some subnets
         """
         currentIPvalue = self.get_ip()
-        if((currentIPvalue.split(".")[2] in CONFIGURED_SUBNETS) and (currentIPvalue[:7] == '10.128.')) or (currentIPvalue[:8] == '10.0.28.') or (currentIPvalue[:7] == '10.0.4.'):
-            # COUNTINGPRU
-            if self.boardID == COUNTINGPRU_SIMAR_ID:
-                self.simar = Simar_addr()
-                self.counter = CountingPRU_addr()
+        if((currentIPvalue.split(".")[2] in CONFIGURED_SUBNETS) and (currentIPvalue.startswith(CONTROLS_INFRA)))
+            or (currentIPvalue.startswith(ISP_INFRA))
+            or (currentIPvalue.startswith(DAT_INFRA)):
+                # COUNTINGPRU
+                if self.boardID == COUNTINGPRU_SIMAR_ID:
+                    self.simar = Simar_addr()
+                    self.counter = CountingPRU_addr()
 
-                if self.simar.identified:
-                    for _ in range(5):
-                        self.status = self.simar.autoConfig_Available()
-                        if self.status:
-                            break
-                        sleep(2)
-                else:
-                    system("/root/counting-pru/src/pinconfig_counting-pru.sh")
-                    for i in range(5):
-                        self.status = self.counter.autoConfig_Available()
-                        if self.status:
-                            break
-                        sleep(2)
-
-            # SERIALxxCON - AUTOCONFIG: RTS and CTS pins tied together (jumper)
-            elif self.boardID == SERIALXXCON_ID:
-                read_usb = self.read_folder()
-
-                if(read_usb.find('ttyUSB') != -1):
-                    for i in range(5):
-                        try:
-                            self.status = serial.Serial("/dev/ttyUSB0").cts
-                        except:
-                            self.status = False
+                    if self.simar.identified:
+                        for _ in range(5):
+                            self.status = self.simar.autoConfig_Available()
+                            if self.status:
+                                break
+                            sleep(2)
+                    else:
+                        system("/root/counting-pru/src/pinconfig_counting-pru.sh")
+                        for i in range(5):
+                            self.status = self.counter.autoConfig_Available()
+                            if self.status:
+                                break
                             sleep(2)
 
-            elif self.boardID == SPIXCONV_ID:
-                read_usb = self.read_folder()
-                self.status = True
+                # SERIALxxCON - AUTOCONFIG: RTS and CTS pins tied together (jumper)
+                elif self.boardID == SERIALXXCON_ID:
+                    read_usb = self.read_folder()
+
+                    if(read_usb.find('ttyUSB') != -1):
+                        for i in range(5):
+                            try:
+                                self.status = serial.Serial("/dev/ttyUSB0").cts
+                            except:
+                                self.status = False
+                                sleep(2)
+
+                elif self.boardID == SPIXCONV_ID:
+                    read_usb = self.read_folder()
+                    self.status = True
 
         # SPIxCONV
         elif self.boardID == SPIXCONV_ID:
@@ -83,12 +92,14 @@ class AutoConfig:
             read_usb = self.read_folder()
             self.status = True
 
-        elif (currentIPvalue[:7] != '10.128.') and (currentIPvalue[:5] != '10.0.') and (currentIPvalue[:8] != '10.20.26'):
-            logger.error("Unknown IP {}. Wait a valid one! Restarting service...".format(
-                                currentIPvalue,
-                            )
-                )
-            system('systemctl restart bbb-function')
+        elif not(currentIPvalue.startswith(CONTROLS_INFRA))
+            and not(currentIPvalue.startswith(DAT_INFRA))
+            and not(currentIPvalue.startswith(ISP_GIE_INFRA)):
+                logger.error("Unknown IP {}. Wait a valid one! Restarting service...".format(
+                                    currentIPvalue,
+                                )
+                    )
+                system('systemctl restart bbb-function')
 
     def get_ip(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -222,7 +233,7 @@ if __name__ == "__main__":
             subnet = mybeagle_config[BBB_IP_1_COLUMN].split(".")[2]
 
             # Update IP, if available
-            if mybbb.currentIP[:7] == '10.128.':
+            if currentIPvalue.startswith(CONTROLS_INFRA):
                 if (IP_AVAILABLE_1 or IP_AVAILABLE_2) and subnet == mybbb.currentSubnet:
                     if IP_AVAILABLE_1:
                         new_ip = mybeagle_config[BBB_IP_1_COLUMN]
@@ -266,14 +277,14 @@ if __name__ == "__main__":
 
 
         # IT network, ISP laboratory. Then:
-        elif(mybbb.type == "SPIxCONV" and mybbb.currentSubnet == "28"):
+        elif(mybbb.type == "SPIxCONV" and currentIPvalue.startswith(ISP_INFRA)):
             mybbb.update_ip_address(
                 "manual",
-                new_ip_address="10.0.28.190",
+                new_ip_address="10.20.11.190",
                 new_mask="255.255.255.0",
-                new_gateway="10.0.28.1",
+                new_gateway="10.20.11.1",
             )
-            logger.info("IT infrastructure, ISP lab! IP {} and BBB hostname: {}".format("10.0.28.190", mybbb.name))
+            logger.info("IT infrastructure, ISP lab! IP {} and BBB hostname: {}".format("10.20.11.190", mybbb.name))
             mybbb.update_hostname(mybbb.name)
 
 

--- a/src/scripts/consts.py
+++ b/src/scripts/consts.py
@@ -28,6 +28,7 @@ BBB_IP_2_COLUMN = "BBB_IP_2"
 BBB_HOSTNAME_COLUMN = "BBB_HOSTNAME"
 CONFIG_FILE = "/root/BBB-CONFIG.json"
 AUTOCONFIG_FILE = "AUTOCONFIG.json"
+AUTOCONFIG_FILE_TMP = AUTOCONFIG_FILE + ".tmp"
 CONTROL_SYSTEM_CONSTS_AUTOCONFIG_FILE = "http://ais-eng-srv-ta.cnpem.br/control-system-constants/beaglebone/control-system-beaglebone.json"
 SEPARATOR = b"-----"
 

--- a/src/scripts/detectEquipment.py
+++ b/src/scripts/detectEquipment.py
@@ -74,14 +74,14 @@ if __name__ == "__main__":
     while not path.isfile(RES_FILE) or not path.isfile(BAUDRATE_FILE):
         logger.info('Searching...')
         try:
-            simar()
-            spixconv()
-            counting_pru()
-            power_supply_pru()
-            thermo_probe()
-            mbtemp()
-            agilent4uhv()
-            mks9376b()
+            power_supply_pru()  # Power supplies
+            mks9376b()          # Vacuum gauges
+            agilent4uhv()       # Ion pumps
+            spixconv()          # Pulsed magnets
+            mbtemp()            # Temperature measurements
+            counting_pru()      # Gamma detectors
+            # simar()
+            # thermo_probe()
             # no_tty()
         except SystemExit:
             exit()


### PR DESCRIPTION
This PR removes the `-c` option from wget call, which was causing partial downloads to be appended at the end of half completed files in some cases. Additionally, to make the retrieval more reliable, this also introduces a temporary file (`AUTOCONFIG_FILE_TMP`) that is only moved into place after a successful, non-empty download, ensuaring atomic updates.

Blocked by #62.